### PR TITLE
Sweep scoped constant definitions for each spec

### DIFF
--- a/lib/microspec/scope.rb
+++ b/lib/microspec/scope.rb
@@ -50,14 +50,8 @@ module Microspec
     end
 
     def spec(description = nil, &block)
-      instance = context.new
-
-      start instance
-
-      spec = Spec.new description, instance: instance, &block
+      spec = Spec.new description, scope: self, &block
       spec.perform
-
-      finish instance
     end
 
     def initialize(description = nil, parent: nil, context: nil, &block)
@@ -71,6 +65,22 @@ module Microspec
       instance_eval(&block)
     end
 
+    def start(context)
+      parent.start context if parent
+
+      setups.each do |setup|
+        context.instance_eval(&setup)
+      end
+    end
+
+    def finish(context)
+      parent.finish context if parent
+
+      teardowns.each do |teardown|
+        context.instance_eval(&teardown)
+      end
+    end
+
     protected
 
     def setups
@@ -78,23 +88,7 @@ module Microspec
     end
 
     def teardowns
-      @_setups ||= []
-    end
-
-    def start(instance)
-      parent.start instance if parent
-
-      setups.each do |setup|
-        instance.instance_exec(&setup)
-      end
-    end
-
-    def finish(instance)
-      parent.finish instance if parent
-
-      teardowns.each do |teardown|
-        instance.instance_exec(&teardown)
-      end
+      @_teardowns ||= []
     end
   end
 end

--- a/spec/microspec/scope.rb
+++ b/spec/microspec/scope.rb
@@ -56,6 +56,32 @@ end
 
 scope do
   setup do
+    class Klass
+    end
+  end
+
+  spec do
+    class Klass
+      def new
+      end
+    end
+
+    asserts(Klass.new.methods).include? :new
+  end
+
+  spec do
+    refutes(Klass.new.methods).include? :new
+  end
+end
+
+spec do
+  raises NameError do
+    Klass.new
+  end
+end
+
+scope do
+  setup do
     $a = :a
   end
 


### PR DESCRIPTION
It would be useful if constants were in their original as defined in their corresponding setup blocks:

```
scope do
  setup do
    class Klass
    end
  end

  spec do
    class Klass
      def message
        'Hello World'
      end
    end

    asserts(Klass.new.message) == 'Hello World'
  end

  spec do
    refutes(Klass.new.methods).include? :message
  end
end
```

Another side-effect of this PR is that constant definitions are scoped:

```
scope do
  setup do
    class Klass
    end
  end

  spec do
    Klass.new
  end
end

spec do
  raises NameError do
    Klass.new
  end
end
```
